### PR TITLE
Add support for ServerAlias

### DIFF
--- a/templates/apache_vhost.j2
+++ b/templates/apache_vhost.j2
@@ -5,6 +5,9 @@
 {% endif %}
 
   ServerName {{ rails_host_fqdn }}
+{% if rails_host_alias is defined %}
+  ServerAlias {{ rails_host_alias }}
+{% endif %}
 
   ErrorLog /var/log/httpd/{{ project_name }}/error_log
   CustomLog /var/log/httpd/{{ project_name }}/access_log combined


### PR DESCRIPTION
Ursus should be called by the name digital in production. This adds the
optional ServerAlias directive when rails_host_alias is defined.