### PR TITLE
Force-install bundler gem

### DIFF
--- a/tasks/capistrano_deploy.yml
+++ b/tasks/capistrano_deploy.yml
@@ -12,6 +12,7 @@
   gem:
     name: bundler
     version: '{{ bundler_version.stdout | trim }}'
+    force: true
     state: present
     user_install: false
 


### PR DESCRIPTION
Bypasses `bundler's executable "bundle" conflicts with /usr/bin/bundle`
question